### PR TITLE
Add key-seq-define-evil for evil-mode state-aware key sequences

### DIFF
--- a/key-seq.el
+++ b/key-seq.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Vyacheslav Levit <dev@vlevit.org>
 ;; Version: 1.0.1
 ;; Created: 15 June 2015
-;; Package-Requires: ((key-chord "0.6"))
+;; Package-Requires: ((key-chord "0.6") (evil "1.15.0"))
 ;; Keywords: convenience keyboard keybindings
 ;; URL: http://github.com/vlevit/key-seq.el
 
@@ -63,6 +63,8 @@
 ;;; Code:
 
 ;;;###autoload
+(require 'evil)
+
 (defun key-seq-define-global (keys command)
   "Define a key sequence of the two keys in KEYS starting a COMMAND.
 \nKEYS can be a string or a vector of two elements. Currently only elements
@@ -100,6 +102,22 @@ If COMMAND is nil, the key-chord is removed."
     (if (eq key1 key2)
         (define-key keymap (vector 'key-chord key1 key2) command)
       (define-key keymap (vector 'key-chord key1 key2) command))))
+
+(defun key-seq-define-evil (state keymap keys command)
+  "Define in KEYMAP, a key sequence of the two keys in KEYS starting a COMMAND.
+\nKEYS can be a string or a vector of two elements. Currently only elements
+that corresponds to ascii codes in the range 32 to 126 can be used.
+\nCOMMAND can be an interactive function, a string, or nil.
+If COMMAND is nil, the key-chord is removed."
+  (if (/= 2 (length keys))
+      (error "Key-chord keys must have two elements"))
+  ;; Exotic chars in a string are >255 but define-key wants 128..255 for those
+  (let ((key1 (logand 255 (aref keys 0)))
+        (key2 (logand 255 (aref keys 1))))
+    ;; (define-key keymap (vector 'key-chord key1 key2) command)
+    (evil-define-key state keymap (vector 'key-chord key1 key2) command)
+    )
+  )
 
 (defun key-seq-unset-global (keys)
   "Remove global key sequence of the two keys in KEYS."


### PR DESCRIPTION
Add `key-seq-define-evil`, a state-aware variant of `key-seq-define` for evil-mode.

It defines an ordered two-key sequence in a specific evil state's keymap, e.g.:

```elisp
(key-seq-define-evil 'normal org-mode-map ";n" 'org-capture)
```

Unlike `key-seq-define`, the binding goes through evil's `evil-define-key*`, so the chord is only active in the given state(s).

Changes:
- Add `evil` as a package dependency and `(require 'evil)`.
- Add `key-seq-define-evil` (`state keymap keys command`).
- Enable lexical-binding and use the `evil-define-key*` function form instead of the `evil-define-key` macro. The macro defers via `after-load-functions` when the keymap argument is lexically scoped (`boundp` can't see lexical bindings), so bindings were never applied; the function form binds immediately.
